### PR TITLE
Correct the param and return type hints of MustUse::health_check_troubleshoot_theme_stylesheet() to allow that method to work properly when hooked to pre_option_stylesheet.

### DIFF
--- a/mu-plugins/troubleshooting-mode.php
+++ b/mu-plugins/troubleshooting-mode.php
@@ -604,11 +604,11 @@ class MustUse {
 	 * Attempt to set one of the default themes, or a theme of the users choosing, as the active one
 	 * during Troubleshooting Mode.
 	 *
-	 * @param string $default
+	 * @param bool|string $default
 	 *
-	 * @return string
+	 * @return bool|string
 	 */
-	function health_check_troubleshoot_theme_stylesheet( string $default ) : string {
+	function health_check_troubleshoot_theme_stylesheet( $default ) {
 		if ( $this->self_fetching_theme ) {
 			return $default;
 		}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/site-health-troubleshooting/issues/2

<!-- The following is a recommended collection of information to include in any Pull Request, please fill it in to the best of your abilities. -->

## Short introduction
<!-- Describe what this Pull Request achieves, this is your elevator pitch. -->

<!-- An original ticket is mandatory for all Pull Requests that are not purely documentation focused, to allow for feedback and discussion if needed. -->
Original ticket: #2


## Description of what the PR accomplishes
<!-- A more thorough description of what problem the PR addresses and how the changes improve on them. -->

By changing to type hints from `string`, the `pre_option_stylesheet` filter is allowed to return `false`.  As is, `get_option()` returns early with an empty string.

## Steps to test / reproduce
<!-- Provide details on how to test your changes, or reproduce the issue they resolve. -->

## Screenshots
<!-- If the changes included are visual, always include screenshots or screencasts, presenting the change both before and after applying the proposed changes. -->

## Checklist
- [ ] I have written unit tests where applicable
- [X] My code follows the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/)
- [ ] My code follows the [WordPress accessibility best practices](https://make.wordpress.org/accessibility/handbook/best-practices/)
- [X] My code is properly documented
- [ ] I've included declarations any potential PII (Personally Identifiable Information) that may be collected by these changes
