### PR TITLE
Update wp-coding-standards/wpcs to 3.4.1

### DIFF
--- a/Troubleshooting/class-loopback.php
+++ b/Troubleshooting/class-loopback.php
@@ -36,7 +36,7 @@ class Loopback {
 	 *
 	 * @return array<string, string>
 	 */
-	static function can_perform_loopback( $disable_plugin_hash = null, $allowed_plugins = null ) {
+	public static function can_perform_loopback( $disable_plugin_hash = null, $allowed_plugins = null ) {
 		$cookies = \wp_unslash( $_COOKIE );
 		$timeout = 10;
 		$headers = array(
@@ -128,7 +128,7 @@ class Loopback {
 	 *
 	 * @return void
 	 */
-	static function loopback_no_plugins() {
+	public static function loopback_no_plugins() {
 		\check_ajax_referer( 'health-check-loopback-no-plugins' );
 
 		if ( ! \current_user_can( 'view_site_health_checks' ) ) {
@@ -240,7 +240,7 @@ class Loopback {
 	 *
 	 * @return void
 	 */
-	static function loopback_test_individual_plugins() : void {
+	public static function loopback_test_individual_plugins(): void {
 		\check_ajax_referer( 'health-check-loopback-individual-plugins' );
 
 		if ( ! \current_user_can( 'view_site_health_checks' ) ) {
@@ -292,7 +292,7 @@ class Loopback {
 		\wp_send_json_success( $response );
 	}
 
-	static function loopback_test_default_theme() : void {
+	public static function loopback_test_default_theme(): void {
 		\check_ajax_referer( 'health-check-loopback-default-theme' );
 
 		if ( ! \current_user_can( 'view_site_health_checks' ) ) {

--- a/Troubleshooting/class-troubleshoot.php
+++ b/Troubleshooting/class-troubleshoot.php
@@ -45,7 +45,7 @@ class Troubleshoot {
 	public function __clone() {}
 	public function __wakeup() {}
 
-	public static function get_instance() : self {
+	public static function get_instance(): self {
 		if ( null === self::$instance ) {
 			self::$instance = new self();
 		}
@@ -216,7 +216,7 @@ class Troubleshoot {
 	 *
 	 * @return void
 	 */
-	static function initiate_troubleshooting_mode( array $allowed_plugins = array() ) : void {
+	public static function initiate_troubleshooting_mode( array $allowed_plugins = array() ): void {
 		if ( ! is_array( $allowed_plugins ) ) {
 			$allowed_plugins = (array) $allowed_plugins;
 		}
@@ -238,7 +238,7 @@ class Troubleshoot {
 	 *
 	 * @return bool
 	 */
-	static function mu_plugin_exists() {
+	public static function mu_plugin_exists() {
 		return file_exists( \WPMU_PLUGIN_DIR . '/troubleshooting-mode.php' );
 	}
 
@@ -261,7 +261,7 @@ class Troubleshoot {
 	 *
 	 * @return bool
 	 */
-	static function setup_must_use_plugin( bool $redirect = true ) : bool {
+	public static function setup_must_use_plugin( bool $redirect = true ): bool {
 		global $wp_filesystem;
 
 		// Make sure the `mu-plugins` directory exists.
@@ -306,7 +306,7 @@ class Troubleshoot {
 	 *
 	 * @return bool
 	 */
-	static function maybe_update_must_use_plugin() {
+	public static function maybe_update_must_use_plugin() {
 		if ( ! self::mu_plugin_exists() ) {
 			return false;
 		}
@@ -346,7 +346,7 @@ class Troubleshoot {
 	 *
 	 * @return void
 	 */
-	static function session_started() {
+	public static function session_started() {
 		self::display_notice(
 			sprintf(
 				'%s<br>%s',
@@ -370,7 +370,7 @@ class Troubleshoot {
 	 *
 	 * @return void
 	 */
-	static function display_notice( $message, $status = 'success' ) {
+	public static function display_notice( $message, $status = 'success' ) {
 		printf(
 			'<div class="notice notice-%s inline"><p>%s</p></div>',
 			\esc_attr( $status ),
@@ -383,7 +383,7 @@ class Troubleshoot {
 	 *
 	 * @return void
 	 */
-	public function admin_notices() : void {
+	public function admin_notices(): void {
 		foreach ( $this->admin_notices as $admin_notice ) {
 			printf(
 				'<div class="notice notice-%s"><p>%s</p></div>',
@@ -406,7 +406,7 @@ class Troubleshoot {
 	 *
 	 * @return bool
 	 */
-	static function get_filesystem_credentials( $args = array() ) : bool {
+	public static function get_filesystem_credentials( $args = array() ): bool {
 		$args = array_merge(
 			array(
 				'page' => 'health-check',
@@ -447,7 +447,7 @@ class Troubleshoot {
 	 *
 	 * @return void
 	 */
-	static function show_enable_troubleshoot_form() {
+	public static function show_enable_troubleshoot_form() {
 		if (
 			isset( $_POST['health-check-troubleshoot-mode'] )
 			&& isset( $_POST['_wpnonce'] )

--- a/Troubleshooting/class-types.php
+++ b/Troubleshooting/class-types.php
@@ -33,5 +33,4 @@ class Types {
 		// Return the converted value.
 		return $value;
 	}
-
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "~1.0.0",
-		"wp-coding-standards/wpcs": "^2.3.0",
+		"wp-coding-standards/wpcs": "^3.4.1",
 		"phpunit/phpunit": "~7.4.0",
 		"phpcompatibility/phpcompatibility-wp": "*",
 		"spatie/phpunit-watcher": "^1.10",
@@ -38,7 +38,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "7.1"
+			"php": "7.2"
 		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2bb1490a40427d71a8a7bf13fe493571",
+    "content-hash": "507aba6df986d4a6d3b969b2ecf1dfaf",
     "packages": [],
     "packages-dev": [
         {
@@ -910,6 +910,181 @@
                 }
             ],
             "time": "2025-10-18T00:05:59+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/39467533fdb742446d68c1d10ac33d625ee0311c",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-07-27T11:13:17+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3391,30 +3566,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -3431,6 +3614,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -3438,7 +3622,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-07-27T11:53:23+00:00"
         },
         {
             "name": "yosymfony/resource-watcher",
@@ -3508,7 +3698,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "7.1"
+        "php": "7.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/mu-plugins/troubleshooting-mode.php
+++ b/mu-plugins/troubleshooting-mode.php
@@ -119,7 +119,7 @@ class MustUse {
 	 *
 	 * @return void
 	 */
-	public function init() : void {
+	public function init(): void {
 		\add_filter( 'option_active_plugins', array( $this, 'health_check_loopback_test_disable_plugins' ) );
 		\add_filter( 'option_active_sitewide_plugins', array( $this, 'health_check_loopback_test_disable_plugins' ) );
 
@@ -175,7 +175,7 @@ class MustUse {
 	 *
 	 * @return void
 	 */
-	public function load_options() : void {
+	public function load_options(): void {
 		$this->disable_hash    = \get_option( 'health-check-disable-plugin-hash', null );
 		$this->allowed_plugins = \get_option( 'health-check-allowed-plugins', array() );
 		$this->active_plugins  = $this->get_unfiltered_plugin_list();
@@ -187,7 +187,7 @@ class MustUse {
 	 *
 	 * @return void
 	 */
-	public function enqueue_assets() : void {
+	public function enqueue_assets(): void {
 		if ( ! \is_admin() ) {
 			return;
 		}
@@ -211,7 +211,7 @@ class MustUse {
 	 *
 	 * @return void
 	 */
-	public function prompt_install_default_theme() : void {
+	public function prompt_install_default_theme(): void {
 		if ( ! empty( $this->has_default_theme() ) ) {
 			return;
 		}
@@ -277,7 +277,7 @@ class MustUse {
 	 *
 	 * @return void
 	 */
-	public function plugin_activated() : void {
+	public function plugin_activated(): void {
 		// Force the database entry for active plugins if someone tried changing plugins while in Troubleshooting Mode.
 		\update_option( 'active_plugins', $this->active_plugins );
 	}
@@ -531,7 +531,7 @@ class MustUse {
 	 *
 	 * @return array<int, string>
 	 */
-	function health_check_loopback_test_disable_plugins( $plugins ) {
+	public function health_check_loopback_test_disable_plugins( $plugins ) {
 		if ( ! $this->is_troubleshooting() || ! $this->override_active ) {
 			return $plugins;
 		}
@@ -565,7 +565,7 @@ class MustUse {
 	 *
 	 * @return string
 	 */
-	function has_default_theme() {
+	public function has_default_theme() {
 		foreach ( $this->default_themes as $default_theme ) {
 			if ( $this->theme_exists( $default_theme ) ) {
 				return $default_theme;
@@ -582,7 +582,7 @@ class MustUse {
 	 *
 	 * @return bool
 	 */
-	function theme_exists( $theme_slug ) {
+	public function theme_exists( $theme_slug ) {
 		return is_dir( WP_CONTENT_DIR . '/themes/' . $theme_slug );
 	}
 
@@ -591,7 +591,7 @@ class MustUse {
 	 *
 	 * @return bool
 	 */
-	function override_theme() {
+	public function override_theme() {
 		if ( ! $this->is_troubleshooting() ) {
 			return false;
 		}
@@ -609,7 +609,7 @@ class MustUse {
 	 *
 	 * @return bool|string
 	 */
-	function health_check_troubleshoot_theme_stylesheet( $default ) {
+	public function health_check_troubleshoot_theme_stylesheet( $default ) {
 		if ( $this->self_fetching_theme ) {
 			return $default;
 		}
@@ -644,7 +644,7 @@ class MustUse {
 	 *
 	 * @return bool|string
 	 */
-	function health_check_troubleshoot_theme_template( $default ) {
+	public function health_check_troubleshoot_theme_template( $default ) {
 		if ( $this->self_fetching_theme ) {
 			return $default;
 		}
@@ -683,13 +683,13 @@ class MustUse {
 	 *
 	 * @return void
 	 */
-	function health_check_troubleshooter_mode_logout() {
+	public function health_check_troubleshooter_mode_logout() {
 		if ( isset( $_COOKIE['wp-health-check-disable-plugins'] ) ) {
 			$this->disable_troubleshooting_mode();
 		}
 	}
 
-	function disable_troubleshooting_mode() : void {
+	public function disable_troubleshooting_mode(): void {
 		unset( $_COOKIE['wp-health-check-disable-plugins'] );
 		setcookie( 'wp-health-check-disable-plugins', '', 0, COOKIEPATH, COOKIE_DOMAIN );
 		\delete_option( 'health-check-allowed-plugins' );
@@ -736,7 +736,7 @@ class MustUse {
 	 *
 	 * @return boolean
 	 */
-	private function validate_action_nonce( string $action, array $assets ) : bool {
+	private function validate_action_nonce( string $action, array $assets ): bool {
 		$nonce_action = sprintf(
 			'%s-%s',
 			$action,
@@ -761,7 +761,7 @@ class MustUse {
 	 *
 	 * @return string
 	 */
-	private function prepare_action_nonce( string $action, array $assets ) : string {
+	private function prepare_action_nonce( string $action, array $assets ): string {
 		$nonce_action = sprintf(
 			'%s-%s',
 			$action,
@@ -779,7 +779,7 @@ class MustUse {
 	 *
 	 * @return void
 	 */
-	function health_check_troubleshoot_get_captures() {
+	public function health_check_troubleshoot_get_captures() {
 		// Disable Troubleshooting Mode.
 		if ( isset( $_GET['health-check-disable-troubleshooting'] ) ) {
 			// Validate the cache or return early.
@@ -1091,7 +1091,7 @@ class MustUse {
 		}
 	}
 
-	private function add_dashboard_notice( string $message, string $severity = 'notice' ) : void {
+	private function add_dashboard_notice( string $message, string $severity = 'notice' ): void {
 		$notices = \get_option( 'health-check-dashboard-notices', array() );
 
 		$notices[] = array(
@@ -1114,7 +1114,7 @@ class MustUse {
 	 *
 	 * @return void
 	 */
-	function health_check_troubleshoot_menu_bar( $wp_menu ) {
+	public function health_check_troubleshoot_menu_bar( $wp_menu ) {
 		// We need some admin functions to make this a better user experience, so include that file.
 		if ( ! \is_admin() ) {
 			require_once \trailingslashit( ABSPATH ) . 'wp-admin/includes/plugin.php';
@@ -1282,7 +1282,7 @@ class MustUse {
 		);
 	}
 
-	public function test_site_state() : bool {
+	public function test_site_state(): bool {
 
 		// Make sure the Health_Check_Loopback class is available to us, in case the primary plugin is disabled.
 		if ( ! method_exists( 'SiteHealth\Troubleshooting\Loopback', 'can_perform_loopback' ) ) {
@@ -1307,7 +1307,7 @@ class MustUse {
 		return true;
 	}
 
-	public function dashboard_widget_scripts() : void {
+	public function dashboard_widget_scripts(): void {
 		// Check that it's the dashboard page, we don't want to disturb any other pages.
 		$screen = \get_current_screen();
 		if ( 'dashboard' !== $screen->id && 'plugins' !== $screen->id ) {
@@ -1315,7 +1315,7 @@ class MustUse {
 		}
 	}
 
-	public function display_dashboard_widget() : void {
+	public function display_dashboard_widget(): void {
 		// Check that it's the dashboard page, we don't want to disturb any other pages.
 		$screen = \get_current_screen();
 		if ( 'dashboard' !== $screen->id && 'plugins' !== $screen->id ) {
@@ -1671,7 +1671,7 @@ class MustUse {
 		<?php
 	}
 
-	public function nonce_confirmation_prompt() : void {
+	public function nonce_confirmation_prompt(): void {
 		// If the nonce-validator is disabled, do not show anything.
 		if ( ! $this->show_nonce_validator ) {
 			return;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,7 @@
 <ruleset name="WordPress Coding Standards">
     <description>Apply WordPress Coding Standards to all Health Check plugin files.</description>
 
-    <config name="installed_paths" value="vendor/wp-coding-standards/wpcs" />
+    <config name="installed_paths" value="vendor/wp-coding-standards/wpcs,vendor/phpcsstandards/phpcsutils,vendor/phpcsstandards/phpcsextra" />
 	<config name="text_domain" value="troubleshooting" />
 
     <rule ref="WordPress-Core"/>
@@ -31,4 +31,8 @@
 		<exclude-pattern>*/mu-plugins/troubleshooting-mode.php</exclude-pattern>
 	</rule>
 
+	<!-- Renaming parameters that shadow reserved keywords risks breaking callers using PHP 8 named arguments. -->
+	<rule ref="Universal.NamingConventions.NoReservedKeywordParameterNames">
+		<severity>0</severity>
+	</rule>
 </ruleset>

--- a/troubleshooting.php
+++ b/troubleshooting.php
@@ -27,7 +27,7 @@ define( 'SITEHEALTH_TROUBLESHOOTING_PLUGIN_DIRECTORY', __DIR__ );
  * Autoloader to ensure all features needed by the Troubleshooting plugin are available.
  */
 spl_autoload_register(
-	function( $class ) {
+	function ( $class ) {
 		$prefix   = 'SiteHealth\\Troubleshooting\\';
 		$base_dir = WP_PLUGIN_DIR . '/troubleshooting/Troubleshooting/';
 
@@ -57,7 +57,7 @@ spl_autoload_register(
  *
  * @return array<string, string>
  */
-function add_tools_tab( array $tabs ) : array {
+function add_tools_tab( array $tabs ): array {
 	return array_merge(
 		$tabs,
 		array(
@@ -73,7 +73,7 @@ function add_tools_tab( array $tabs ) : array {
  *
  * @return void
  */
-function add_tools_tab_content( string $tab ) : void {
+function add_tools_tab_content( string $tab ): void {
 	if ( 'troubleshooting' !== $tab ) {
 		return;
 	}
@@ -86,7 +86,7 @@ function add_tools_tab_content( string $tab ) : void {
  *
  * @return void
  */
-function register_actions() : void {
+function register_actions(): void {
 	if ( ! \is_admin() || ! \current_user_can( 'manage_options' ) ) {
 		return;
 	}


### PR DESCRIPTION
Same migration as WordPress/site-health-tools#5, for the troubleshooting plugin:

- Bumps [wp-coding-standards/wpcs](https://github.com/WordPress/WordPress-Coding-Standards) from `^2.3.0` to `^3.4.1` and regenerates `composer.lock`.
- Raises `config.platform.php` from 7.1 to 7.2 — WPCS 3.x requires PHP ≥7.2; affects dependency resolution only.
- Extends the hardcoded `installed_paths` in `phpcs.xml.dist` to also register PHPCSUtils and PHPCSExtra, without which phpcs 3.x dies on `Universal.*` sniff references.
- Fixes all violations: `phpcbf` formatting fixes and explicit `public` visibility on 22 methods (behavior-neutral).
- Silences `Universal.NamingConventions.NoReservedKeywordParameterNames` (3 warnings): renaming parameters like `$default`/`$class` risks breaking PHP 8 named-argument callers — left as a maintainer judgment call.

**Verification:** full `phpcs` scan is completely clean.

Part of an org-wide sweep to get all repos onto WPCS 3.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)